### PR TITLE
Use Java 17 by default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'gradle'
     - run: gradle assemble --info
     - run: gradle test --info
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
     - run: sbt -v 'Test / compile' assembly
     - run: sbt -v test
     - run: java -jar build/pipeline.jar --inputText="🎉"
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'maven'
     - run: mvn -DskipTests test-compile package
     - run: mvn test

--- a/README.md
+++ b/README.md
@@ -8,16 +8,12 @@ you can choose the license you prefer and feel free to delete anything related t
 Make sure you have a [Java](https://en.wikipedia.org/wiki/Java_%28programming_language%29) development environment ready.
 If you don't, an easy way to install it is with [`sdkman`](https://sdkman.io).
 
-> ℹ️ Apache Beam currently only supports Java 8 (LTS) and Java 11 (LTS).
->
-> ⚠️ **[Java 8 ends its active support in March 2022](https://endoflife.date/java)**, so we recommend using Java 11 (LTS) until Java 17 (LTS) is supported.
-
 ```sh
 # Install sdkman.
 curl -s "https://get.sdkman.io" | bash
 
-# Make sure you have Java 11 installed.
-sdk install java 11.0.12-tem
+# Make sure you have Java 17 installed.
+sdk install java 17.0.5-tem
 ```
 
 ## Source file structure
@@ -31,7 +27,7 @@ There are only two source files:
 
 > ℹ️ Most build tools expect all the Java source files to be under `src/main/java/` and tests to be under `src/test/java/` by default.
 
-### Option A: Gradle
+### Option A: Gradle _(recommended)_
 
 [Gradle](https://gradle.org) is a build tool focused on flexibility and performance.
 
@@ -98,7 +94,7 @@ sbt assembly
 java -jar build/pipeline.jar --inputText="🎉"
 ```
 
-### Option C: Apache Maven _(not recommended)_
+### Option C: Apache Maven
 
 [Apache Maven](http://maven.apache.org) is a project management and comprehension tool based on the concept of a project object model (POM).
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,10 @@ test {
     useJUnit()
 }
 
-def beamVersion = '2.42.0'
 dependencies {
     // App dependencies.
-    implementation "org.apache.beam:beam-sdks-java-core:${beamVersion}"
-    implementation "org.apache.beam:beam-runners-direct-java:${beamVersion}"
+    implementation "org.apache.beam:beam-sdks-java-core:2.42.0"
+    implementation "org.apache.beam:beam-runners-direct-java:2.42.0"
     implementation "org.slf4j:slf4j-jdk14:1.7.32"
 
     // Tests dependencies.

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@
 
 mainClass := Some("com.example.App")
 
-val beamVersion = "2.39.0"
+val beamVersion = "2.42.0"
 libraryDependencies ++= Seq(
   // App dependencies.
   "org.apache.beam" % "beam-sdks-java-core" % beamVersion,

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,9 @@
   <version>1</version>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <beam.version>2.40.0</beam.version>
-    <junit.version>4.13.2</junit.version>
   </properties>
 
   <build>
@@ -83,13 +80,13 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-core</artifactId>
-      <version>${beam.version}</version>
+      <version>2.42.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-direct-java</artifactId>
-      <version>${beam.version}</version>
+      <version>2.42.0</version>
       <scope>runtime</scope>
     </dependency>
 
@@ -103,7 +100,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
This PR does the following changes:
* Use Java 17 by default.
* Inline dependency versions instead of using variables, so Dependabot can update them

R: @aaltay 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] I agree that my contributions are licensed with both [Apache ASL2](../../LICENSE-APACHE) and [MIT](../../LICENSE-MIT).
 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [`CONTRIBUTING.md`](../../CONTRIBUTING.md) guide for more information.
