### PR TITLE
Revert "Bump actions/checkout from 3.3.0 to 3.5.2"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
   Gradle:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v3.3.0
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
@@ -27,7 +27,7 @@ jobs:
   sbt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v3.3.0
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
   Maven:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v3.3.0
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'


### PR DESCRIPTION
Reverts apache/beam-starter-java#59

Didn't notice gradle test was failing :-/ 